### PR TITLE
Fix random test failures on Mac

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,6 @@ updates:
       - dependency-name: dependency-check
       - dependency-name: nyc
       - dependency-name: standard
-      # ESM-only
-      - dependency-name: tempy
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,11 +4,13 @@ permissions:
   contents: read
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        node: [12, 14, 16]
-    name: Node ${{ matrix.node }}
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        node: [12, 14, 16, 18]
+    name: Node ${{ matrix.node }} on ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "nyc": "^15.1.0",
     "standard": "^16.0.3",
     "tape": "^5.0.1",
-    "tempy": "^1.0.1",
     "ts-standard": "^11.0.0",
     "typescript": "^4.5.5"
   },

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const test = require('tape')
-const tempy = require('tempy')
+const tempy = require('./util/tempy')
 const path = require('path')
 const events = require('events')
 const { RaveLevel } = require('..')

--- a/test/bytewise.js
+++ b/test/bytewise.js
@@ -2,7 +2,7 @@
 
 const test = require('tape')
 const bytewise = require('bytewise')
-const tempy = require('tempy')
+const tempy = require('./util/tempy')
 const { RaveLevel } = require('..')
 
 test('bytewise key encoding', function (t) {

--- a/test/election.js
+++ b/test/election.js
@@ -2,7 +2,7 @@
 
 const test = require('tape')
 const { once } = require('events')
-const tempy = require('tempy')
+const tempy = require('./util/tempy')
 const { RaveLevel } = require('..')
 
 test('basic failover', async function (t) {

--- a/test/multi-process.js
+++ b/test/multi-process.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const test = require('tape')
-const tempy = require('tempy')
+const tempy = require('./util/tempy')
 const { once } = require('events')
 const { fork } = require('child_process')
 const { RaveLevel } = require('..')
@@ -14,24 +14,27 @@ if (process.argv[2] === 'child') {
     if (err) throw err
   })
 } else {
-  test('multiple processes', async function (t) {
-    const location = tempy.directory()
-    const entries = []
-    const promises = []
-    const exits = []
+  // Repeat because we have/had random issues here
+  for (let i = 0; i < 20; i++) {
+    test(`multiple processes (${i})`, async function (t) {
+      const location = tempy.directory()
+      const entries = []
+      const promises = []
+      const exits = []
 
-    for (let i = 0; i < 10; i++) {
-      const key = String(i).padStart(5, '0')
-      const value = String(Math.random())
-      const argv = ['child', location, key, value]
-      const child = fork(__filename, argv, { timeout: 30e3 })
+      for (let i = 0; i < 10; i++) {
+        const key = String(i).padStart(5, '0')
+        const value = String(Math.random())
+        const argv = ['child', location, key, value]
+        const child = fork(__filename, argv, { timeout: 30e3 })
 
-      entries.push([key, value])
-      promises.push(once(child, 'exit'))
-      exits.push([0, null])
-    }
+        entries.push([key, value])
+        promises.push(once(child, 'exit'))
+        exits.push([0, null])
+      }
 
-    t.same(await Promise.all(promises), exits)
-    t.same(await new RaveLevel(location).iterator().all(), entries)
-  })
+      t.same(await Promise.all(promises), exits)
+      t.same(await new RaveLevel(location).iterator().all(), entries)
+    })
+  }
 }

--- a/test/open-close.js
+++ b/test/open-close.js
@@ -2,7 +2,7 @@
 
 const test = require('tape')
 const { once } = require('events')
-const tempy = require('tempy')
+const tempy = require('./util/tempy')
 const { RaveLevel } = require('..')
 
 test('self-flush', async function (t) {

--- a/test/sublevel.js
+++ b/test/sublevel.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const test = require('tape')
-const tempy = require('tempy')
+const tempy = require('./util/tempy')
 const { RaveLevel } = require('..')
 
 test('sublevel', function (t) {

--- a/test/util/tempy.js
+++ b/test/util/tempy.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const path = require('path')
+const crypto = require('crypto')
+const fs = require('fs')
+const tmp = require('os').tmpdir()
+
+// We previously used https://www.npmjs.com/package/tempy but it
+// returns directories that are too long. On Mac, the maximum length
+// of a unix domain socket is 104 bytes. Exceeding that can result
+// in EADDRINUSE errors.
+exports.directory = function () {
+  const dir = path.join(tmp, crypto.randomBytes(10).toString('hex'))
+  fs.mkdirSync(dir)
+  return dir
+}


### PR DESCRIPTION
Using `tempy` to generate random temporary directories results in unix domain socket names that are too long ([104 bytes is the max on Mac](https://unix.stackexchange.com/questions/367008/why-is-socket-path-length-limited-to-a-hundred-chars)) which manifests itself as EADDRINUSE errors (discovered in #3). So replace `tempy` with a simple alternative.

Also expands the CI test matrix, adding Node.js 18 and Windows and Mac, to test platform differences in the handling of sockets.